### PR TITLE
#7 refactor: 장바구니 출력 시 담은 순서대로 출력

### DIFF
--- a/src/main/java/level6/Cart.java
+++ b/src/main/java/level6/Cart.java
@@ -1,14 +1,13 @@
 package level6;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Scanner;
 
 public class Cart {
     // menuItem(메뉴명, 가격정보)과 수량을 저장
-    final Map<MenuItem, Integer> cartItems = new HashMap<>();
+    final Map<MenuItem, Integer> cartItems = new LinkedHashMap<>();
 
     // 장바구니 담기
     public void addItem(MenuItem item) {
@@ -21,16 +20,10 @@ public class Cart {
 
     // 장바구니 출력
     private void printCart() {
-        // 주문 목록 출력 시 메뉴명 오름차순 정렬
-        List<Map.Entry<MenuItem, Integer>> entryList = cartItems.entrySet()
-                .stream()
-                .sorted(Map.Entry.<MenuItem, Integer>comparingByKey())
-                .toList();
-
-        for (Map.Entry<MenuItem, Integer> entry : entryList) {
+        for (Map.Entry<MenuItem, Integer> entry : cartItems.entrySet()) {
             MenuItem item = entry.getKey();
             String name = item.getName();
-            double price = entry.getValue() * item.getPrice();
+            BigDecimal price = BigDecimal.valueOf(entry.getValue() * item.getPrice());
             String description = item.getDescription();
             System.out.printf("%-21s | W %.1f | %s%n", name, price, description);
         }

--- a/src/main/java/level6/MenuItem.java
+++ b/src/main/java/level6/MenuItem.java
@@ -1,6 +1,6 @@
 package level6;
 
-public class MenuItem implements Comparable<MenuItem> {
+public class MenuItem {
     private final String name; // 이름
     private final Double price; // 가격
     private final String description; // 설명
@@ -26,18 +26,5 @@ public class MenuItem implements Comparable<MenuItem> {
     @Override
     public String toString() {
         return String.format("%-21s | W %.1f | %s", name, price, description);
-    }
-
-    @Override
-    public int compareTo(MenuItem o) {
-        // 길이 비교
-        if (this.name.length() > o.name.length()) {
-            return 1;
-        } else if (this.name.length() < o.name.length()) {
-            return -1;
-        } else {
-            // 길이가 같으면 사전순
-            return this.name.compareTo(o.name);
-        }
     }
 }


### PR DESCRIPTION
#7 refactor: 장바구니 출력 수정
Cart.printCart()
주문 시 장바구니의 목록(영수증)을 출력할 때
메뉴명 정렬보다 장바구니에 담은 순서를 보장하는 것이 적합하다고 판단

#6 에서 수정한 사항을 rollback
HashMap을 LinkedHashMap으로 수정